### PR TITLE
Macでもpip installできるように更新しました

### DIFF
--- a/creversi_cpp/board.hpp
+++ b/creversi_cpp/board.hpp
@@ -43,8 +43,13 @@ unsigned char _bittestandreset64(long long *a, long long b)
 #define _mm256_set_m128i(v0, v1)  _mm256_insertf128_si256(_mm256_castsi128_si256(v1), (v0), 1)
 #define _mm256_setr_m128i(v0, v1) _mm256_set_m128i((v1), (v0))
 
+#ifdef __APPLE__
+#include <machine/endian.h>
+#define _byteswap_uint64(x) _bswap64(x)
+#else
 #include <byteswap.h>
 #define _byteswap_uint64(x) bswap_64(x)
+#endif
 
 #define _rotr64 __rorq
 #endif


### PR DESCRIPTION
Macで`pip install git+https://github.com/TadaoYamaoka/creversi`を実行すると以下のようなエラーが出ました。
`#ifdef __APPLE__`によりMacでpip installする場合のエラーを解決しました。
もしお時間あれば、アップデートの反映を検討頂けると大変ありがたく存じます。
もし不適切な修正であればより良い方法がないか探したいと思っています。

```
$ pip install git+https://github.com/TadaoYamaoka/creversi
Collecting git+https://github.com/TadaoYamaoka/creversi
  Cloning https://github.com/TadaoYamaoka/creversi to /private/var/folders/hl/xrycfdz539d79hms3cqm94tr0000gn/T/pip-req-build-joxvj3kl
  Running command git clone -q https://github.com/TadaoYamaoka/creversi /private/var/folders/hl/xrycfdz539d79hms3cqm94tr0000gn/T/pip-req-build-joxvj3kl
Building wheels for collected packages: creversi
  Building wheel for creversi (setup.py) ... error
  ERROR: Complete output from command /anaconda3/bin/python -u -c 'import setuptools, tokenize;__file__='"'"'/private/var/folders/hl/xrycfdz539d79hms3cqm94tr0000gn/T/pip-req-build-joxvj3kl/setup.py'"'"';f=getattr(tokenize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' bdist_wheel -d /private/var/folders/hl/xrycfdz539d79hms3cqm94tr0000gn/T/pip-wheel-cocr_r6e --python-tag cp37:
  ERROR: running bdist_wheel
  running build
  running build_py
  creating build
  creating build/lib.macosx-10.7-x86_64-3.7
  creating build/lib.macosx-10.7-x86_64-3.7/creversi
  copying creversi/__init__.py -> build/lib.macosx-10.7-x86_64-3.7/creversi
  copying creversi/GGF.py -> build/lib.macosx-10.7-x86_64-3.7/creversi
  creating build/lib.macosx-10.7-x86_64-3.7/creversi/gym_reversi
  copying creversi/gym_reversi/__init__.py -> build/lib.macosx-10.7-x86_64-3.7/creversi/gym_reversi
  creating build/lib.macosx-10.7-x86_64-3.7/creversi/gym_reversi/envs
  copying creversi/gym_reversi/envs/__init__.py -> build/lib.macosx-10.7-x86_64-3.7/creversi/gym_reversi/envs
  running build_ext
  cythoning creversi/creversi.pyx to creversi/creversi.cpp
  /anaconda3/lib/python3.7/site-packages/Cython/Compiler/Main.py:367: FutureWarning: Cython directive 'language_level' not set, using 2 for now (Py2). This will change in a later release! File: /private/var/folders/hl/xrycfdz539d79hms3cqm94tr0000gn/T/pip-req-build-joxvj3kl/creversi/creversi.pyx
    tree = Parsing.p_module(s, pxd, full_module_name)
  building 'creversi.creversi' extension
  creating build/temp.macosx-10.7-x86_64-3.7
  creating build/temp.macosx-10.7-x86_64-3.7/creversi
  creating build/temp.macosx-10.7-x86_64-3.7/creversi_cpp
  gcc -Wno-unused-result -Wsign-compare -Wunreachable-code -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -I/anaconda3/include -arch x86_64 -I/anaconda3/include -arch x86_64 -Icreversi_cpp -I/anaconda3/lib/python3.7/site-packages/numpy/core/include -I/anaconda3/include/python3.7m -c creversi/creversi.cpp -o build/temp.macosx-10.7-x86_64-3.7/creversi/creversi.o -std=c++11 -msse4.2 -mbmi -mbmi2 -mavx2
  cc1plus: warning: command line option '-Wstrict-prototypes' is valid for C/ObjC but not for C++
  In file included from /anaconda3/lib/python3.7/site-packages/numpy/core/include/numpy/ndarraytypes.h:1824,
                   from /anaconda3/lib/python3.7/site-packages/numpy/core/include/numpy/ndarrayobject.h:12,
                   from /anaconda3/lib/python3.7/site-packages/numpy/core/include/numpy/arrayobject.h:4,
                   from creversi/creversi.cpp:633:
  /anaconda3/lib/python3.7/site-packages/numpy/core/include/numpy/npy_1_7_deprecated_api.h:17:2: warning: #warning "Using deprecated NumPy API, disable it with " "#define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION" [-Wcpp]
     17 | #warning "Using deprecated NumPy API, disable it with " \
        |  ^~~~~~~
  In file included from creversi_cpp/utils.hpp:7,
                   from creversi/creversi.cpp:635:
  creversi_cpp/board.hpp:46:10: fatal error: byteswap.h: No such file or directory
     46 | #include <byteswap.h>
        |          ^~~~~~~~~~~~
  compilation terminated.
  error: command 'gcc' failed with exit status 1
  ----------------------------------------
  ERROR: Failed building wheel for creversi
  Running setup.py clean for creversi
Failed to build creversi
```